### PR TITLE
Added support for IE 11

### DIFF
--- a/SimpleFieldSelect.js
+++ b/SimpleFieldSelect.js
@@ -1824,12 +1824,12 @@ define( ["qlik", "jquery", "css!./SimpleFieldStyle.css","text!./datepicker.css",
 					var filters = [];
 					if (pr.searchExcelCopypaste){
 						filters = filter.split("\n").join('|s|').split("\t").join('|s|').split('|s|');
-						filters = filters.map(str => str.trim());
+						filters = filters.map(function (str) { return str.trim() });
 						filters = filters.filter(function(el) { return el; }); //remove empty
 					} else 
 					if(pr.exportenableMultisearchWith){
 						filters = filter.split(pr.exportenableMultisearchWith);
-						filters = filters.map(str => str.trim());
+						filters = filters.map(function (str) { return str.trim() });
 						filters = filters.filter(function(el) { return el; }); //remove empty
 					} else {
 						filters.push(filter);


### PR DESCRIPTION
Currently running on IE11 throws this error:

![image](https://user-images.githubusercontent.com/99223/69888971-8b799300-12e6-11ea-8180-2ce5ccce3485.png)

I simply changed from ES6 fat arrow syntax to "old school" function syntax.